### PR TITLE
Add new option "allowIdChange" 

### DIFF
--- a/src/xliffmerge/i-xliff-merge-options.ts
+++ b/src/xliffmerge/i-xliff-merge-options.ts
@@ -24,6 +24,7 @@ export interface IConfigFile {
 export interface IXliffMergeOptions {
     quiet?: boolean;   // Flag to only output error messages
     verbose?: boolean;   // Flag to generate debug output messages
+    allowIdChange?: boolean; // Try to find translation even when id is missing
     defaultLanguage?: string;    // the default language (the language, which is used in the original templates)
     languages?: string[];   // all languages, if not specified via commandline
     srcDir?: string;    // Directory, where the master file is

--- a/src/xliffmerge/xliff-merge-parameters.ts
+++ b/src/xliffmerge/xliff-merge-parameters.ts
@@ -17,6 +17,7 @@ export class XliffMergeParameters {
 
     private _quiet: boolean;
     private _verbose: boolean;
+    private _allowIdChange: boolean;
     private _defaultLanguage: string;
     private _srcDir: string;
     private _i18nFile: string;
@@ -115,6 +116,9 @@ export class XliffMergeParameters {
             }
             if (!isNullOrUndefined(profile.verbose)) {
                 this._verbose = profile.verbose;
+            }
+            if(!isNullOrUndefined(profile.allowIdChange)) {
+                this._allowIdChange = profile.allowIdChange;
             }
             if (profile.defaultLanguage) {
                 this._defaultLanguage = profile.defaultLanguage;
@@ -243,6 +247,10 @@ export class XliffMergeParameters {
         if (!pattern.test(lang)) {
             this.errorsFound.push(new XliffMergeError('language "' + lang + '" is not valid'));
         }
+    }
+
+    public allowIdChange(): boolean {
+        return (isNullOrUndefined(this._allowIdChange)) ? false : this._allowIdChange;
     }
 
     public verbose(): boolean {


### PR DESCRIPTION
that try to find translation when there is change in source tabulation

This is common situation when you write translations as:
```html
<div>
   <div class="many css classes here"
        i18n="Some long meaning here">
    Some source translation
    </div>
<div>
```

When you move this div block to parent div, tabulation of source text is changed, therefore id of translation is also different and it is recognized as new translation.

This change adds option that will try to recover from that situation.