### PR TITLE
Escape '>' in XmlSerializer

### DIFF
--- a/projects/ngx-i18nsupport-lib/src/impl/xml-serializer.ts
+++ b/projects/ngx-i18nsupport-lib/src/impl/xml-serializer.ts
@@ -161,11 +161,11 @@ export class XmlSerializer {
                 return;
             case node.ATTRIBUTE_NODE:
                 const attrNode = <Attr> node;
-                return buf.push(' ', attrNode.name, '="', attrNode.value.replace(/[<&"]/g, this._xmlEncoder), '"');
+                return buf.push(' ', attrNode.name, '="', attrNode.value.replace(/[<>&"]/g, this._xmlEncoder), '"');
             case node.TEXT_NODE:
                 const textNode = <Text> node;
                 if (!options.beautify || partOfMixedContent || !this.containsOnlyWhiteSpace(textNode.data)) {
-                    return buf.push(textNode.data.replace(/[<&]/g, this._xmlEncoder));
+                    return buf.push(textNode.data.replace(/[<>&]/g, this._xmlEncoder));
                 }
                 return;
             case node.CDATA_SECTION_NODE:


### PR DESCRIPTION
fixes: #165

Not sure if this repository is active anymore since it's not been touched in awhile and there seems to be a number of open PRs, but @sbaramov it's probably easiest to create a PR in the future :slightly_smiling_face: (I attributed you as the commit author).

I noticed the same thing and figured it must just be valid XML :shrug: but was looking at open issues and PR and saw #165 